### PR TITLE
Correct typos in question 9

### DIFF
--- a/faq.html
+++ b/faq.html
@@ -99,7 +99,7 @@
       <li><a href="https://www.nuget.org/packages/DuoUniversal/">NuGet</a></li>      
       <li><a href="https://github.com/duosecurity/duo_universal_golang">Golang</a></li>      
     </ul>
-    <p>You can find a step-by-step example of updating an existing Web SDK v2 application to the Universal Prompt<a href="https://github.com/duosecurity/duo_python/pull/57">here</a>.</p>
+    <p>You can find a step-by-step example of updating an existing Web SDK v2 application to the Universal Prompt <a href="https://github.com/duosecurity/duo_python/pull/57">here</a>.</p>
     <p>Another option for web applications with OIDC support is to use our OIDC-based API.  See our <a href="https://duo.com/docs/oauthapi">documentation</a> for more information.</p>
     <p>And for web applications with SAML support, consider implementing the best of both worlds with <a href="https://duo.com/docs/sso">Duo Single Sign-On</a> and/or <a href="https://duo.com/docs/passwordless">Duo Passwordless</a></p>
     <div id="Question10">


### PR DESCRIPTION
- There was an extraneous '.' in one of the links
- replaced "out documentation" with "our documentation"