### PR TITLE
Remove statement that duo_wordpress does not have a replacement

### DIFF
--- a/faq.html
+++ b/faq.html
@@ -24,7 +24,7 @@
             <li><a href="#Question9">How do I upgrade an application to the Universal Prompt?</a></li>
             <li><a href="#Question10">What does deprecation of the Web SDK v2 GitHub repositories mean?</a></li>
             <li><a href="#Question11">What will happen to the Web SDK v2 packages in package managers, for example PyPi?</a></li>
-            <li><a href="#Question12">What about Web SDK v2 GitHub repositories that don't have a Universal Prompt version?  Like duo_ruby, duo_perl, or duo_wordpress?</a></li>
+            <li><a href="#Question12">What about Web SDK v2 GitHub repositories that don't have a Universal Prompt version?  Like duo_ruby or duo_perl?</a></li>
           </ul>
         </div>
     </div>
@@ -118,7 +118,7 @@
       <li><a href="https://packagist.org/packages/duosecurity/duo_php">PHP / Packagist</a></li>
     </ul>
     <div id="Question12">
-      <h3>What about Web SDK v2 GitHub repositories that don't have a Universal Prompt version?  Like duo_ruby, duo_perl, or duo_wordpress?</h3>
+      <h3>What about Web SDK v2 GitHub repositories that don't have a Universal Prompt version?  Like duo_ruby or duo_perl?</h3>
   </div>
   <p>Even though there are no replacements at this time, we will still be deprecating this category of repositories.  To implement a Universal Prompt integration in one of these languages or applications, you can use the Duo OIDC Auth API described at <a href="https://duo.com/docs/oauthapi">https://duo.com/docs/oauthapi</a>.</p>
     </div>


### PR DESCRIPTION
## Description
Removing the language that indicates duo_wordpress does not have a replacement

## Motivation and Context
Because it will

## How Has This Been Tested?
N/A

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
